### PR TITLE
Testes agora compilam

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 .idea/
 *.iml
 node_modules
+.vscode/

--- a/modules/opla-core/src/test/java/br/otimizes/oplatool/core/jmetal4/learning/SubjectiveAnalyzeAlgorithmTest.java
+++ b/modules/opla-core/src/test/java/br/otimizes/oplatool/core/jmetal4/learning/SubjectiveAnalyzeAlgorithmTest.java
@@ -19,6 +19,8 @@ import br.otimizes.oplatool.core.jmetal4.problems.OPLA;
 import br.otimizes.oplatool.core.learning.ClusteringAlgorithm;
 import br.otimizes.oplatool.core.learning.Moment;
 import br.otimizes.oplatool.core.learning.SubjectiveAnalyzeAlgorithm;
+import br.otimizes.oplatool.domain.OPLAThreadScope;
+import br.otimizes.oplatool.domain.config.ApplicationYamlConfig;
 import br.otimizes.oplatool.domain.config.FileConstants;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -70,6 +72,12 @@ public class SubjectiveAnalyzeAlgorithmTest {
                 }
             }
         }
+
+        ApplicationYamlConfig applicationYamlConfig = new ApplicationYamlConfig();
+        applicationYamlConfig.setDirectoryToExportModels("");
+        applicationYamlConfig.setDirectoryToSaveModels("");
+        applicationYamlConfig.setPathToTemplateModelsDirectory("");
+        OPLAThreadScope.setConfig(applicationYamlConfig);
 
         SubjectiveAnalyzeAlgorithm subjectiveAnalyzeAlgorithm = algorithm.getSubjectiveAnalyzeAlgorithm();
         List<Element> truePositive = subjectiveAnalyzeAlgorithm.getNotFreezedElements().stream()


### PR DESCRIPTION
Corrigi o teste SubjectiveAnalyzeAlgorithmTest e agora ele funciona normalmente e não mais causa erros ao rodar mvn install (eliminando a necessidade de utilizar o argumento de linha de comando --DskipTests).